### PR TITLE
Fix xmlrpclib for Py3

### DIFF
--- a/erppeek_wst.py
+++ b/erppeek_wst.py
@@ -3,7 +3,7 @@
 
 from erppeek import Client, Service
 import functools
-import xmlrpclib
+from six.moves import xmlrpc_client as xmlrpclib
 
 
 class ClientWST(Client):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     url='http://github.com/totaler/erppeek_wst',
     author='Joan M. Grande',
     author_email='totaler@gmail.com',
-    install_requires=['erppeek'],
+    install_requires=['erppeek', 'six'],
     py_modules=['erppeek_wst'],
     platforms='any',
     keywords="openerp xml-rpc xmlrpc",


### PR DESCRIPTION
Use six to import compatible xmlrpclib from python 2 or 3